### PR TITLE
Style improvements for aggregate-json example

### DIFF
--- a/samples/aggregate-json/src/index.ts
+++ b/samples/aggregate-json/src/index.ts
@@ -21,8 +21,6 @@ async function aggregateJson(): Promise<Response> {
 }
 
 //@ts-ignore
-addEventListener('fetch', async (event: FetchEvent) => {
+addEventListener('fetch', (event: FetchEvent) => {
     event.respondWith(aggregateJson());
 });
-
-export {}

--- a/samples/aggregate-json/tsconfig.json
+++ b/samples/aggregate-json/tsconfig.json
@@ -14,5 +14,8 @@
         "strict": true,
         "noImplicitReturns": true,
         "moduleResolution": "node"
-    }
+    },
+    "include": [
+        "src/**/*"
+    ]
 }


### PR DESCRIPTION
After writing this sample, we found that fetch callbacks should not be async, and that tsconfig was the better place to address the duplicate functions issue.  We applied those tweaks to the template; this realigns the sample with them too.

@karthik2804 sorry for not spotting your comment about this until after I had mashed the merge button on the previous PR...
