### PR TITLE
update README/spin.toml to match current process

### DIFF
--- a/samples/large-scale-redirects/README.md
+++ b/samples/large-scale-redirects/README.md
@@ -18,6 +18,21 @@ for compact storage of target URLs.
 
 The `rules-manager` CLI validates, merges, and encodes redirect rules from plain text to optimized binary formats.
 
+## Prerequisites
+
+- [Rust toolchain](https://www.rust-lang.org/tools/install) (stable version)
+- The `wasm32-wasip1` target for Rust: `rustup target add wasm32-wasip1`
+- [wizer](https://github.com/bytecodealliance/wizer): `cargo install wizer --all-features`
+
+Install the prerequisites using:
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+rustup target add wasm32-wasip1
+cargo install wizer --all-features
+```
+
 ### Build the CLI
 
 ```shell
@@ -64,15 +79,13 @@ To adjust the set of words used, edit the script itself.
 ### Run the CLI
 
 ```shell
-./rules-manager \
-  --existing-rules existing_validated.txt \   # Optional: One or more previously validated rule files
-  --add-rules new_rules1.txt new_rules2.txt \ # Optional: One or more new rule files
-  --default-status-code 302 \                 # Default status code for redirects (default: 302)
-  --include-existing \                        # Optional: Include existing rules in output
-  --output-dir ./output \                     # Store all output files here (default: current directory)
-  --rules-output-file merged.txt \            # Where to store new validated rules (default: new_redirects.txt)
-  --encoded-sources sources.fst \             # Binary FST output (default: sources.fst)
-  --encoded-targets targets.fcsd              # Binary FCSD output (default: targets.fcsd)
+./target/release/rules-manager \
+  --add-rules example-redirects.txt \  # Optional: One or more new rule files
+  --include-existing \                 # Optional: Include existing rules in output
+  --output-dir ./output \              # Store all output files here (default: current directory)
+  --rules-output-file redirects.txt \  # Where to store new validated rules (default: new_redirects.txt)
+  --encoded-sources sources.fst \      # Binary FST output (default: sources.fst)
+  --encoded-targets targets.fcsd       # Binary FCSD output (default: targets.fcsd)
 ```
 
 #### Validation Options
@@ -123,8 +136,8 @@ Typical workflow for deploying redirects:
 
 ### Prerequisites
 
-Besides Spin, building the redirecter component requires the [wizer](https://github.com/bytecodealliance/wizer)
-WebAssembly snapshotting tool.
+Besides Spin, building the redirecter component requires the
+[wizer](https://github.com/bytecodealliance/wizer) WebAssembly snapshot tool.
 
 ### Building
 

--- a/samples/large-scale-redirects/spin.toml
+++ b/samples/large-scale-redirects/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "redirects-rs"
 
 [component.redirects-rs]
-source = "target/redirect.wasm"
+source = "redirects.wasm"
 allowed_outbound_hosts = []
 [component.redirects-rs.build]
-command = "./build.sh example-redirects.txt"
+command = "./build.sh sources.fst targets.fcsd 302 redirects.wasm"
 watch = ["src/**/*.rs", "Cargo.toml", "build.sh", "redirects.txt"]


### PR DESCRIPTION
A few feature flags present in the README don't exist in the tool. Furthermore build.sh accepts a different set of arguments than what's been provided in spin.toml.

With this, the process to compile the project is now:

```
cd samples/large-scale-redirects
cargo build --release -p rules-manager
./target/release/rules-manager --add-rules example-redirects.txt --rules-output-file redirects.txt
spin build
```

closes #48